### PR TITLE
Made compatible to Express 4.x

### DIFF
--- a/lib/connect-lazydb.js
+++ b/lib/connect-lazydb.js
@@ -3,7 +3,7 @@ var lazydb = require('lazydb');
 var oneDay = 86400;
 
 module.exports = function (connect) {
-    var Store = connect.session.Store;
+    var Store = connect.Store || connect.session.Store;
 
     function LazyStore(options) {
         options = options || {};


### PR DESCRIPTION
In Express 4.x, express.session does not exist any more, but is put into npm module express-session.
So now if you want to use it use mongoStore(expressSession)
